### PR TITLE
ci: disallow failure on php 8.4 latest

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,20 +14,20 @@ jobs:
       matrix:
         include:
           - php: 8.2
-            allow_fail: true
+            allow_fail: false
             php_ini: 'xdebug.coverage_enable=On'
             name: 'PHP 8.2 with latest deps'
           - php: 8.2
-            allow_fail: true
+            allow_fail: false
             composer_update_flags: '--prefer-lowest --prefer-stable'
             php_ini: 'xdebug.coverage_enable=On'
             name: 'PHP 8.2 with lowest stable deps'
           - php: 8.3
-            allow_fail: true
+            allow_fail: false
             php_ini: 'xdebug.coverage_enable=On'
             name: 'PHP 8.3 with latest deps'
           - php: 8.3
-            allow_fail: true
+            allow_fail: false
             composer_update_flags: '--prefer-lowest --prefer-stable'
             php_ini: 'xdebug.coverage_enable=On'
             name: 'PHP 8.3 with lowest stable deps'
@@ -36,7 +36,7 @@ jobs:
             php_ini: 'xdebug.coverage_enable=On'
             name: 'PHP 8.4 with latest deps'
           - php: 8.4
-            allow_fail: true
+            allow_fail: false
             composer_update_flags: '--prefer-lowest --prefer-stable'
             php_ini: 'xdebug.coverage_enable=On'
             name: 'PHP 8.4 with lowest stable deps'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
             php_ini: 'xdebug.coverage_enable=On'
             name: 'PHP 8.3 with lowest stable deps'
           - php: 8.4
-            allow_fail: true
+            allow_fail: false
             php_ini: 'xdebug.coverage_enable=On'
             name: 'PHP 8.4 with latest deps'
           - php: 8.4

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /.idea/
 /meta-data.json
 /.phpunit.result.cache
+/.phpunit.cache/
 /composer.lock

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,28 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.4/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         executionOrder="depends,defects"
-         forceCoversAnnotation="true"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         verbose="true">
-    <testsuites>
-        <testsuite name="unit">
-            <directory suffix="Test.php">tests/Unit</directory>
-        </testsuite>
-        <testsuite name="integration">
-            <directory suffix="Test.php">tests/Integration</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">MetaDataTool</directory>
-        </whitelist>
-    </filter>
-
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+        bootstrap="vendor/autoload.php"
+        executionOrder="random"
+        beStrictAboutOutputDuringTests="true"
+        cacheDirectory=".phpunit.cache"
+        requireCoverageMetadata="true"
+>
+  <coverage>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="unit">
+      <directory suffix="Test.php">tests/Unit</directory>
+    </testsuite>
+    <testsuite name="integration">
+      <directory suffix="Test.php">tests/Integration</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <source>
+    <include>
+      <directory suffix=".php">MetaDataTool</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/Integration/EndpointCrawlerTest.php
+++ b/tests/Integration/EndpointCrawlerTest.php
@@ -9,13 +9,12 @@ use MetaDataTool\Crawlers\EndpointCrawler;
 use MetaDataTool\PageRegistry;
 use MetaDataTool\ValueObjects\Endpoint;
 use MetaDataTool\ValueObjects\Property;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(EndpointCrawler::class)]
 class EndpointCrawlerTest extends TestCase
 {
-    /**
-     * @covers \MetaDataTool\Crawlers\EndpointCrawler
-     */
     public function testItCanParseCrmAccountPage(): void
     {
         $config = new EndpointCrawlerConfig(false);
@@ -41,9 +40,6 @@ class EndpointCrawlerTest extends TestCase
         self::assertContains('BSN', $propertyNames);
     }
 
-    /**
-     * @covers \MetaDataTool\Crawlers\EndpointCrawler
-     */
     public function testItCanDetectHiddenIsSerialNumberProperty(): void
     {
         $config = new EndpointCrawlerConfig(false);
@@ -65,9 +61,6 @@ class EndpointCrawlerTest extends TestCase
         self::assertTrue($isSerialNumberProperty->isHidden());
     }
 
-    /**
-     * @covers \MetaDataTool\Crawlers\EndpointCrawler
-     */
     public function testInvokesCallbackOnEndpointDiscovery(): void
     {
         $documentation = 'https://start.exactonline.nl/docs/HlpRestAPIResourcesDetails.aspx?name=LogisticsItems';

--- a/tests/Integration/MainPageCrawlerCrawlerTest.php
+++ b/tests/Integration/MainPageCrawlerCrawlerTest.php
@@ -11,13 +11,12 @@ use MetaDataTool\DocumentationCrawler;
 use MetaDataTool\PageRegistry;
 use MetaDataTool\ValueObjects\Endpoint;
 use MetaDataTool\ValueObjects\Property;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(MainPageCrawler::class)]
 class MainPageCrawlerCrawlerTest extends TestCase
 {
-    /**
-     * @covers \MetaDataTool\Crawlers\MainPageCrawler
-     */
     public function testitCanCrawlMainPage(): void
     {
         $crawler = new MainPageCrawler('https://start.exactonline.nl/docs/HlpRestAPIResources.aspx');
@@ -27,6 +26,5 @@ class MainPageCrawlerCrawlerTest extends TestCase
         self::assertTrue($result->hasAny());
         $next = $result->next();
         self::assertStringStartsWith('https://start.exactonline.nl/docs', $next);
-
     }
 }

--- a/tests/Unit/Config/EndpointCrawlerConfigTest.php
+++ b/tests/Unit/Config/EndpointCrawlerConfigTest.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace MetaDataTool\Tests\Unit\Config;
 
 use MetaDataTool\Config\EndpointCrawlerConfig;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(EndpointCrawlerConfig::class)]
 class EndpointCrawlerConfigTest extends TestCase
 {
-    /**
-     * @covers \MetaDataTool\Config\EndpointCrawlerConfig
-     */
     public function testValueObjectHoldsAttributes(): void
     {
         $config = new EndpointCrawlerConfig(true);

--- a/tests/Unit/JsonFileWriterTest.php
+++ b/tests/Unit/JsonFileWriterTest.php
@@ -6,12 +6,11 @@ namespace MetaDataTool\Tests\Unit;
 
 use MetaDataTool\JsonFileWriter;
 use MetaDataTool\ValueObjects\EndpointCollection;
+use PHPUnit\Framework\Attributes\CoversClass;
 
+#[CoversClass(JsonFileWriter::class)]
 class JsonFileWriterTest extends TestCase
 {
-    /**
-     * @covers \MetaDataTool\JsonFileWriter
-     */
     public function testCanWriteToAnExistingDirectory(): void
     {
         $writer = new JsonFileWriter(sys_get_temp_dir());
@@ -20,9 +19,6 @@ class JsonFileWriterTest extends TestCase
         $this->assertFileExists(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'meta-data.json');
     }
 
-    /**
-     * @covers \MetaDataTool\JsonFileWriter
-     */
     public function testCanWriteToNewDirectory(): void
     {
         $subDir = $this->faker()->domainWord;
@@ -34,9 +30,6 @@ class JsonFileWriterTest extends TestCase
         );
     }
 
-    /**
-     * @covers \MetaDataTool\JsonFileWriter
-     */
     public function testThrowsExceptionOnUncreatableDirectory(): void
     {
         $this->expectException(\RuntimeException::class);

--- a/tests/Unit/PageRegistryTest.php
+++ b/tests/Unit/PageRegistryTest.php
@@ -6,13 +6,12 @@ namespace MetaDataTool\Tests\Unit;
 
 use MetaDataTool\Exception\Exception;
 use MetaDataTool\PageRegistry;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(PageRegistry::class)]
 class PageRegistryTest extends TestCase
 {
-    /**
-     * @covers \MetaDataTool\PageRegistry
-     */
     public function testHasPageReturnsFalseWithNewRegistry(): void
     {
         $registry = new PageRegistry();
@@ -20,9 +19,6 @@ class PageRegistryTest extends TestCase
         self::assertFalse($registry->hasPage('www.example.org'));
     }
 
-    /**
-     * @covers \MetaDataTool\PageRegistry
-     */
     public function testHasPageReturnsTrueWithPageAdded(): void
     {
         $page = 'https://www.example.org';
@@ -32,9 +28,6 @@ class PageRegistryTest extends TestCase
         self::assertTrue($registry->hasPage($page));
     }
 
-    /**
-     * @covers \MetaDataTool\PageRegistry
-     */
     public function testHasAnyReturnsFalseWithNewRegistry(): void
     {
         $registry = new PageRegistry();
@@ -42,9 +35,6 @@ class PageRegistryTest extends TestCase
         self::assertFalse($registry->hasAny());
     }
 
-    /**
-     * @covers \MetaDataTool\PageRegistry
-     */
     public function testHasAnyReturnsTrueWithPageAdded(): void
     {
         $page = 'https://www.example.org';
@@ -54,9 +44,6 @@ class PageRegistryTest extends TestCase
         self::assertTrue($registry->hasAny());
     }
 
-    /**
-     * @covers \MetaDataTool\PageRegistry
-     */
     public function testNextReturnsPageWithPageAdded(): void
     {
         $page = 'https://www.example.org';
@@ -66,9 +53,6 @@ class PageRegistryTest extends TestCase
         self::assertEquals($page, $registry->next());
     }
 
-    /**
-     * @covers \MetaDataTool\PageRegistry
-     */
     public function testNextThrowsExceptionWithNewRegistry(): void
     {
         $registry = new PageRegistry();
@@ -77,9 +61,6 @@ class PageRegistryTest extends TestCase
         $registry->next();
     }
 
-    /**
-     * @covers \MetaDataTool\PageRegistry
-     */
     public function testCountReturnsCorrectValue(): void
     {
         $registry = new PageRegistry();
@@ -90,9 +71,6 @@ class PageRegistryTest extends TestCase
         self::assertEquals(3, $registry->count());
     }
 
-    /**
-     * @covers \MetaDataTool\PageRegistry
-     */
     public function testGetIteratorReturnCorrectIterator(): void
     {
         $pages = [

--- a/tests/Unit/ValueObjects/EndpointCollectionTest.php
+++ b/tests/Unit/ValueObjects/EndpointCollectionTest.php
@@ -9,21 +9,17 @@ use MetaDataTool\ValueObjects\Endpoint;
 use MetaDataTool\ValueObjects\EndpointCollection;
 use MetaDataTool\ValueObjects\HttpMethodMask;
 use MetaDataTool\ValueObjects\PropertyCollection;
+use PHPUnit\Framework\Attributes\CoversClass;
 
+#[CoversClass(EndpointCollection::class)]
 class EndpointCollectionTest extends TestCase
 {
-    /**
-     * @covers \MetaDataTool\ValueObjects\EndpointCollection
-     */
     public function testConstructorIsProtectedAgainstWrongType(): void
     {
         $this->expectException(\TypeError::class);
         new EndpointCollection(new \stdClass());
     }
 
-    /**
-     * @covers \MetaDataTool\ValueObjects\EndpointCollection
-     */
     public function testCanAddEndpointToCollection(): void
     {
         $collection = new EndpointCollection();
@@ -42,17 +38,11 @@ class EndpointCollectionTest extends TestCase
         self::assertContains($endpoint, $collection);
     }
 
-    /**
-     * @covers \MetaDataTool\ValueObjects\EndpointCollection
-     */
     public function testObjectIsIterable(): void
     {
         self::assertIsIterable(new EndpointCollection());
     }
 
-    /**
-     * @covers \MetaDataTool\ValueObjects\EndpointCollection
-     */
     public function testCollectionCanBeCorrectlySerialised(): void
     {
         $endpoint = new Endpoint(
@@ -73,9 +63,6 @@ class EndpointCollectionTest extends TestCase
         );
     }
 
-    /**
-     * @covers \MetaDataTool\ValueObjects\EndpointCollection
-     */
     public function testCollectionCanBeCorrectlyDeserialised(): void
     {
         $json = (string) json_encode(new EndpointCollection(new Endpoint(

--- a/tests/Unit/ValueObjects/EndpointTest.php
+++ b/tests/Unit/ValueObjects/EndpointTest.php
@@ -8,12 +8,11 @@ use MetaDataTool\ValueObjects\Endpoint;
 use MetaDataTool\ValueObjects\HttpMethodMask;
 use MetaDataTool\ValueObjects\PropertyCollection;
 use MetaDataTool\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
+#[CoversClass(Endpoint::class)]
 class EndpointTest extends TestCase
 {
-    /**
-     * @covers \MetaDataTool\ValueObjects\Endpoint
-     */
     public function testValueObjectHoldsAttributes(): void
     {
         $endpoint = new Endpoint(
@@ -37,9 +36,6 @@ class EndpointTest extends TestCase
         self::assertEquals($deprecated, $endpoint->isDeprecated());
     }
 
-    /**
-     * @covers \MetaDataTool\ValueObjects\Endpoint
-     */
     public function testPropertyCanBeCorrectlySerialised(): void
     {
         $endpoint = new Endpoint(
@@ -68,9 +64,6 @@ class EndpointTest extends TestCase
         );
     }
 
-    /**
-     * @covers \MetaDataTool\ValueObjects\Endpoint
-     */
     public function testPropertyCanBeCorrectlyDeserialised(): void
     {
         $json = (string) json_encode(new Endpoint(

--- a/tests/Unit/ValueObjects/HttpMethodMaskTest.php
+++ b/tests/Unit/ValueObjects/HttpMethodMaskTest.php
@@ -6,12 +6,11 @@ namespace MetaDataTool\Tests\Unit\ValueObjects;
 
 use MetaDataTool\Tests\Unit\TestCase;
 use MetaDataTool\ValueObjects\HttpMethodMask;
+use PHPUnit\Framework\Attributes\CoversClass;
 
+#[CoversClass(HttpMethodMask::class)]
 class HttpMethodMaskTest extends TestCase
 {
-    /**
-     * @covers \MetaDataTool\ValueObjects\HttpMethodMask
-     */
     public function testNamedConstructorAllSupportsAll(): void
     {
         $methods = HttpMethodMask::all();
@@ -22,9 +21,6 @@ class HttpMethodMaskTest extends TestCase
         $this->assertTrue($methods->supportsDelete());
     }
 
-    /**
-     * @covers \MetaDataTool\ValueObjects\HttpMethodMask
-     */
     public function testNamedConstructorNoneSupportsNone(): void
     {
         $methods = HttpMethodMask::none();
@@ -35,9 +31,6 @@ class HttpMethodMaskTest extends TestCase
         $this->assertFalse($methods->supportsDelete());
     }
 
-    /**
-     * @covers \MetaDataTool\ValueObjects\HttpMethodMask
-     */
     public function testAddGetReturnsMethodAsSupported(): void
     {
         $methods = HttpMethodMask::none()->addGet();
@@ -45,9 +38,6 @@ class HttpMethodMaskTest extends TestCase
         $this->assertTrue($methods->supportsGet());
     }
 
-    /**
-     * @covers \MetaDataTool\ValueObjects\HttpMethodMask
-     */
     public function testAddPostReturnsMethodAsSupported(): void
     {
         $methods = HttpMethodMask::none()->addPost();
@@ -55,9 +45,6 @@ class HttpMethodMaskTest extends TestCase
         $this->assertTrue($methods->supportsPost());
     }
 
-    /**
-     * @covers \MetaDataTool\ValueObjects\HttpMethodMask
-     */
     public function testAddPutReturnsMethodAsSupported(): void
     {
         $methods = HttpMethodMask::none()->addPut();
@@ -65,9 +52,6 @@ class HttpMethodMaskTest extends TestCase
         $this->assertTrue($methods->supportsPut());
     }
 
-    /**
-     * @covers \MetaDataTool\ValueObjects\HttpMethodMask
-     */
     public function testAddDeleteReturnsMethodAsSupported(): void
     {
         $methods = HttpMethodMask::none()->addDelete();
@@ -75,9 +59,6 @@ class HttpMethodMaskTest extends TestCase
         $this->assertTrue($methods->supportsDelete());
     }
 
-    /**
-     * @covers \MetaDataTool\ValueObjects\HttpMethodMask
-     */
     public function testPropertyCanBeCorrectlySerialised(): void
     {
         $methods = HttpMethodMask::all();
@@ -93,9 +74,6 @@ class HttpMethodMaskTest extends TestCase
         );
     }
 
-    /**
-     * @covers \MetaDataTool\ValueObjects\HttpMethodMask
-     */
     public function testPropertyCanBeCorrectlyDeserialised(): void
     {
         $json = (string) json_encode(HttpMethodMask::all(), JSON_THROW_ON_ERROR);

--- a/tests/Unit/ValueObjects/PropertyCollectionTest.php
+++ b/tests/Unit/ValueObjects/PropertyCollectionTest.php
@@ -8,29 +8,22 @@ use MetaDataTool\Tests\Unit\TestCase;
 use MetaDataTool\ValueObjects\HttpMethodMask;
 use MetaDataTool\ValueObjects\Property;
 use MetaDataTool\ValueObjects\PropertyCollection;
+use PHPUnit\Framework\Attributes\CoversClass;
 
+#[CoversClass(PropertyCollection::class)]
 class PropertyCollectionTest extends TestCase
 {
-    /**
-     * @covers \MetaDataTool\ValueObjects\PropertyCollection
-     */
     public function testConstructorIsProtectedAgainstWrongType(): void
     {
         $this->expectException(\TypeError::class);
         new PropertyCollection(new \stdClass());
     }
 
-    /**
-     * @covers \MetaDataTool\ValueObjects\PropertyCollection
-     */
     public function testObjectIsIterable(): void
     {
         self::assertIsIterable(new PropertyCollection());
     }
 
-    /**
-     * @covers \MetaDataTool\ValueObjects\PropertyCollection
-     */
     public function testCollectionCanBeCorrectlySerialised(): void
     {
         $property = new Property(
@@ -50,9 +43,6 @@ class PropertyCollectionTest extends TestCase
         );
     }
 
-    /**
-     * @covers \MetaDataTool\ValueObjects\PropertyCollection
-     */
     public function testCollectionCanBeCorrectlyDeserialised(): void
     {
         $json = (string) json_encode(new PropertyCollection(new Property(
@@ -79,10 +69,7 @@ class PropertyCollectionTest extends TestCase
         );
     }
 
-    /**
-     * @covers \MetaDataTool\ValueObjects\PropertyCollection
-     */
-    public function testCollectionReturnsCorectIterator(): void
+    public function testCollectionReturnsCorrectIterator(): void
     {
         $propertyOne = new Property(
             $this->faker()->name,

--- a/tests/Unit/ValueObjects/PropertyRowParserConfigTest.php
+++ b/tests/Unit/ValueObjects/PropertyRowParserConfigTest.php
@@ -6,12 +6,11 @@ namespace MetaDataTool\Tests\Unit\ValueObjects;
 
 use MetaDataTool\Tests\Unit\TestCase;
 use MetaDataTool\ValueObjects\PropertyRowParserConfig;
+use PHPUnit\Framework\Attributes\CoversClass;
 
+#[CoversClass(PropertyRowParserConfig::class)]
 class PropertyRowParserConfigTest extends TestCase
 {
-    /**
-     * @covers \MetaDataTool\ValueObjects\PropertyRowParserConfig
-     */
     public function testValueObjectHoldsAttributes(): void
     {
         $config = new PropertyRowParserConfig(

--- a/tests/Unit/ValueObjects/PropertyTest.php
+++ b/tests/Unit/ValueObjects/PropertyTest.php
@@ -7,12 +7,11 @@ namespace MetaDataTool\Tests\Unit\ValueObjects;
 use MetaDataTool\ValueObjects\HttpMethodMask;
 use MetaDataTool\ValueObjects\Property;
 use MetaDataTool\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
 
+#[CoversClass(Property::class)]
 class PropertyTest extends TestCase
 {
-    /**
-     * @covers \MetaDataTool\ValueObjects\Property
-     */
     public function testValueObjectHoldsAttributes(): void
     {
         $property = new Property(
@@ -34,9 +33,6 @@ class PropertyTest extends TestCase
         self::assertTrue($property->isMandatory());
     }
 
-    /**
-     * @covers \MetaDataTool\ValueObjects\Property
-     */
     public function testPropertyCanBeCorrectlySerialised(): void
     {
         $property = new Property(
@@ -63,9 +59,6 @@ class PropertyTest extends TestCase
         );
     }
 
-    /**
-     * @covers \MetaDataTool\ValueObjects\Property
-     */
     public function testPropertyCanBeCorrectlyDeserialised(): void
     {
         $json = (string) json_encode(new Property(


### PR DESCRIPTION
This pull request focuses on updating the PHPUnit configuration, modifying the GitHub Actions workflow, and improving test coverage annotations. The most important changes include updating the PHPUnit schema, changing the workflow matrix to disallow failures, and replacing `@covers` annotations with `#[CoversClass]` attributes.

### PHPUnit Configuration Updates:
* [`phpunit.xml.dist`](diffhunk://#diff-e35810879ec42bdd81797b3ccb72f6de28a8b4a0e3bfdba43183e133e866b892L2-R15): Updated the PHPUnit schema to version 11.5, changed execution order to random, added cache directory, and included coverage reporting configuration. [[1]](diffhunk://#diff-e35810879ec42bdd81797b3ccb72f6de28a8b4a0e3bfdba43183e133e866b892L2-R15) [[2]](diffhunk://#diff-e35810879ec42bdd81797b3ccb72f6de28a8b4a0e3bfdba43183e133e866b892L18-R29)

### GitHub Actions Workflow:
* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L17-R39): Changed `allow_fail` from `true` to `false` for all PHP versions in the matrix to ensure all jobs must pass.

### Test Coverage Annotations:
* [`tests/Integration/EndpointCrawlerTest.php`](diffhunk://#diff-b580abc4d512b694b71e69f09fb1753938ae44375265c8fb23b00ae78d68d40bR12-L18): Replaced `@covers` annotations with `#[CoversClass(EndpointCrawler::class)]` attribute. [[1]](diffhunk://#diff-b580abc4d512b694b71e69f09fb1753938ae44375265c8fb23b00ae78d68d40bR12-L18) [[2]](diffhunk://#diff-b580abc4d512b694b71e69f09fb1753938ae44375265c8fb23b00ae78d68d40bL44-L46) [[3]](diffhunk://#diff-b580abc4d512b694b71e69f09fb1753938ae44375265c8fb23b00ae78d68d40bL68-L70)
* [`tests/Integration/MainPageCrawlerCrawlerTest.php`](diffhunk://#diff-67492ad8a3f4060975b2d1e7a557f54bdb9fd04daae9069d263c9fd6d91daca0R14-L20): Replaced `@covers` annotations with `#[CoversClass(MainPageCrawler::class)]` attribute. [[1]](diffhunk://#diff-67492ad8a3f4060975b2d1e7a557f54bdb9fd04daae9069d263c9fd6d91daca0R14-L20) [[2]](diffhunk://#diff-67492ad8a3f4060975b2d1e7a557f54bdb9fd04daae9069d263c9fd6d91daca0L30)
* [`tests/Unit/Config/EndpointCrawlerConfigTest.php`](diffhunk://#diff-1653c0ce2070bba9591665c43537a72689b566f94a2d6a07e3b3507a151af8a9R8-L14): Replaced `@covers` annotations with `#[CoversClass(EndpointCrawlerConfig::class)]` attribute.
* [`tests/Unit/JsonFileWriterTest.php`](diffhunk://#diff-f8223d0d2d2711b4edece3d3491686c5b3c8536007d5888c9b469bbc4fa168fbR9-L14): Replaced `@covers` annotations with `#[CoversClass(JsonFileWriter::class)]` attribute. [[1]](diffhunk://#diff-f8223d0d2d2711b4edece3d3491686c5b3c8536007d5888c9b469bbc4fa168fbR9-L14) [[2]](diffhunk://#diff-f8223d0d2d2711b4edece3d3491686c5b3c8536007d5888c9b469bbc4fa168fbL23-L25) [[3]](diffhunk://#diff-f8223d0d2d2711b4edece3d3491686c5b3c8536007d5888c9b469bbc4fa168fbL37-L39)
* [`tests/Unit/PageRegistryTest.php`](diffhunk://#diff-da8a2eb9ad9587255a6d7549a32c2f2857bf9f90ed06d3432d7881f3b3ed192eR9-L25): Replaced `@covers` annotations with `#[CoversClass(PageRegistry::class)]` attribute. [[1]](diffhunk://#diff-da8a2eb9ad9587255a6d7549a32c2f2857bf9f90ed06d3432d7881f3b3ed192eR9-L25) [[2]](diffhunk://#diff-da8a2eb9ad9587255a6d7549a32c2f2857bf9f90ed06d3432d7881f3b3ed192eL35-L47) [[3]](diffhunk://#diff-da8a2eb9ad9587255a6d7549a32c2f2857bf9f90ed06d3432d7881f3b3ed192eL57-L59) [[4]](diffhunk://#diff-da8a2eb9ad9587255a6d7549a32c2f2857bf9f90ed06d3432d7881f3b3ed192eL69-L71) [[5]](diffhunk://#diff-da8a2eb9ad9587255a6d7549a32c2f2857bf9f90ed06d3432d7881f3b3ed192eL80-L82) [[6]](diffhunk://#diff-da8a2eb9ad9587255a6d7549a32c2f2857bf9f90ed06d3432d7881f3b3ed192eL93-L95)
* [`tests/Unit/ValueObjects/EndpointCollectionTest.php`](diffhunk://#diff-e67176285098c9b4331e5d98883902cb1739b100d765134b6f8c82ac108199a4R12-L26): Replaced `@covers` annotations with `#[CoversClass(EndpointCollection::class)]` attribute. [[1]](diffhunk://#diff-e67176285098c9b4331e5d98883902cb1739b100d765134b6f8c82ac108199a4R12-L26) [[2]](diffhunk://#diff-e67176285098c9b4331e5d98883902cb1739b100d765134b6f8c82ac108199a4L45-L55) [[3]](diffhunk://#diff-e67176285098c9b4331e5d98883902cb1739b100d765134b6f8c82ac108199a4L76-L78)
* [`tests/Unit/ValueObjects/EndpointTest.php`](diffhunk://#diff-36c74b12808f6edd80cb6f474b61736791c70e7b28a91f687b538516e614e4f2R11-L16): Replaced `@covers` annotations with `#[CoversClass(Endpoint::class)]` attribute. [[1]](diffhunk://#diff-36c74b12808f6edd80cb6f474b61736791c70e7b28a91f687b538516e614e4f2R11-L16) [[2]](diffhunk://#diff-36c74b12808f6edd80cb6f474b61736791c70e7b28a91f687b538516e614e4f2L40-L42) [[3]](diffhunk://#diff-36c74b12808f6edd80cb6f474b61736791c70e7b28a91f687b538516e614e4f2L71-L73)
* [`tests/Unit/ValueObjects/HttpMethodMaskTest.php`](diffhunk://#diff-f6e99f45a69f561e83a1aebf3df8d90b9f1a45d4abb96b98e9f09430a5420640R9-L14): Replaced `@covers` annotations with `#[CoversClass(HttpMethodMask::class)]` attribute. [[1]](diffhunk://#diff-f6e99f45a69f561e83a1aebf3df8d90b9f1a45d4abb96b98e9f09430a5420640R9-L14) [[2]](diffhunk://#diff-f6e99f45a69f561e83a1aebf3df8d90b9f1a45d4abb96b98e9f09430a5420640L25-L27) [[3]](diffhunk://#diff-f6e99f45a69f561e83a1aebf3df8d90b9f1a45d4abb96b98e9f09430a5420640L38-L80) [[4]](diffhunk://#diff-f6e99f45a69f561e83a1aebf3df8d90b9f1a45d4abb96b98e9f09430a5420640L96-L98)
* [`tests/Unit/ValueObjects/PropertyCollectionTest.php`](diffhunk://#diff-2086effc098bd1ccafff60c9085803d882687924246e83801a928d845f14a0c7R11-L33): Replaced `@covers` annotations with `#[CoversClass(PropertyCollection::class)]` attribute.